### PR TITLE
Fix DefaultResourcePackMixin failing to compile

### DIFF
--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/DefaultResourcePackMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/DefaultResourcePackMixin.java
@@ -101,7 +101,7 @@ public abstract class DefaultResourcePackMixin {
 		return this.internalPack.findResources(type, namespace, prefix, maxDepth, pathFilter);
 	}
 
-	@Inject(method = "close", at = @At("HEAD"))
+	@Inject(method = "close", at = @At("HEAD"), remap = false)
 	private void onClose(CallbackInfo ci) {
 		this.internalPack.close();
 	}


### PR DESCRIPTION
The `close` method isn't in the refmap since it's a JDK method, and apparently Mixin hates that enough to prevent the mod from compiling, so have this one-liner of a PR.