### PR TITLE
fixed end biome source injection

### DIFF
--- a/library/worldgen/biome/src/main/java/org/quiltmc/qsl/worldgen/biome/mixin/TheEndBiomeSourceMixin.java
+++ b/library/worldgen/biome/src/main/java/org/quiltmc/qsl/worldgen/biome/mixin/TheEndBiomeSourceMixin.java
@@ -58,6 +58,9 @@ public abstract class TheEndBiomeSourceMixin extends BiomeSource {
 	@Unique
 	private boolean quilt$hasAddedBiomes = false;
 
+	@Unique
+	private boolean quilt$checkedAddedBiomes = false;
+
 	/**
 	 * Modifies the codec, so it calls the static factory method that gives us access to the
 	 * full biome registry instead of just the pre-defined biomes that vanilla uses.
@@ -83,8 +86,12 @@ public abstract class TheEndBiomeSourceMixin extends BiomeSource {
 	public Set<Holder<Biome>> getBiomes() {
 		var biomes = super.getBiomes();
 
-		if (!this.quilt$hasAddedBiomes) {
-			this.quilt$hasAddedBiomes = true;
+		if (!this.quilt$checkedAddedBiomes) {
+			this.quilt$checkedAddedBiomes = true;
+			this.quilt$hasAddedBiomes = !this.overrides.get().getAddedBiomes().isEmpty();
+		}
+
+		if (this.quilt$hasAddedBiomes) {
 			biomes = new HashSet<>(biomes);
 			biomes.addAll(this.overrides.get().getAddedBiomes());
 		}


### PR DESCRIPTION
```
[18:08:10] [Server thread/INFO] (QuiltBiome|QuiltBiomeTest) Biome ResourceKey[minecraft:worldgen/biome / quilt_biome_testmod:test_end_highlands] has been found at BlockPos{x=832, y=90, z=768}.
[18:08:11] [Server thread/INFO] (QuiltBiome|QuiltBiomeTest) Biome ResourceKey[minecraft:worldgen/biome / quilt_biome_testmod:test_end_midlands] has been found at BlockPos{x=768, y=90, z=704}.
[18:08:14] [Server thread/INFO] (QuiltBiome|QuiltBiomeTest) Biome ResourceKey[minecraft:worldgen/biome / quilt_biome_testmod:test_end_barrens] has been found at BlockPos{x=864, y=90, z=608}.
```